### PR TITLE
Fixed initialisation of opportunity in a new project

### DIFF
--- a/extensions/GrandObjectPage/LIMSPmm/Views/LIMSContactEditViewPmm.js
+++ b/extensions/GrandObjectPage/LIMSPmm/Views/LIMSContactEditViewPmm.js
@@ -220,13 +220,4 @@ LIMSContactEditViewPmm = Backbone.View.extend({
         this.changeDetails();
         return this.$el;
     },
-
-    afterRender: function(){
-        _.defer(function(){
-            if(this.model.get('opportunities').length == 0){
-                this.addOpportunity();
-            }
-        }.bind(this));
-    }
-
 });

--- a/extensions/GrandObjects/BackboneModels/LIMSContactPmm.js
+++ b/extensions/GrandObjects/BackboneModels/LIMSContactPmm.js
@@ -10,6 +10,11 @@ LIMSContactPmm = Backbone.Model.extend({
                 this.opportunities.fetch();
             }.bind(this));
         //}
+        this.listenTo(this.opportunities, "sync", function() {
+            if (this.opportunities.length === 0) {
+                this.opportunities.add(new LIMSOpportunityPmm());
+            }
+        });
         this.opportunities.on("add", function(model){
             model.contact = this;
         }.bind(this));


### PR DESCRIPTION
Fixed: https://github.com/UniversityOfAlberta/GrandForum/issues/265

`afterRender` function is called after ever render and a render happens during the saving as well and somehow that overwrites the tasks associated with the opportunity. But there are a lot of complex interactions going on during render + saving, so I am not entirely sure what is going on. Anyhow, modifying the state during render is not ideal in many frameworks. 

Following, similar logic I moved the initial opportunity creation to the initialization in LIMSContactPmm model. Now, by listening for the sync event on the opportunities collection, we guarantee that the new opportunity is only created once and in a more robust manner.