### PR TITLE
Add an option to assign everybody to a task

### DIFF
--- a/extensions/GrandObjectPage/LIMSPmm/Templates/lims_status_change.html
+++ b/extensions/GrandObjectPage/LIMSPmm/Templates/lims_status_change.html
@@ -1,7 +1,7 @@
 <h3>Select New Status</h3>
 
 <% 
-if (assignees && assignees.length > 0) { 
+if (displayAssignees && displayAssignees.length > 0) { 
 %>
     <table class="wikitable">
         <thead>
@@ -14,17 +14,17 @@ if (assignees && assignees.length > 0) {
             </tr>
         </thead>
         <tbody>
-            <% assignees.forEach(function(assignee, index) { %>
+            <% displayAssignees.forEach(function(assignee, index) { %>
                 <tr>
                     <td valign="top"><%= assignee.name %></td>
                     <td valign="top">
                         <% 
                         var assigneeId = (assignee.id != undefined) ? assignee.id : assignee; 
-                        var currentStatus = statuses[assigneeId]; // Get current status for the assignee
+                        var currentStatus = displayStatuses[assigneeId]; // Get current status for the assignee
                         %>
                         
                         <% if (isLeaderAllowedToEdit || (me.get('id') == assigneeId && (currentStatus == 'Assigned' || currentStatus == 'Done'))) { %> 
-                            <%= HTML.Select(this, 'statuses.' + assigneeId, { 
+                            <%= HTML.Select(this, 'displayStatuses.' + assigneeId, { 
                                 options: 
                                     isLeaderAllowedToEdit 
                                         ? ['New', 'Assigned', 'Done', 'Closed'] 
@@ -36,7 +36,7 @@ if (assignees && assignees.length > 0) {
                     </td>
                     <td valign="top" height>
                       <% 
-                        var fileObj  = (files && files[assigneeId]) || {};
+                        var fileObj  = (displayFiles && displayFiles[assigneeId]) || {};
                         var filename = fileObj.filename || '';
                         var toDelete = fileObj.delete || false;
                       %>
@@ -46,7 +46,7 @@ if (assignees && assignees.length > 0) {
                                 <%= filename %>
                                   <span class="delete-icon deleteFile" data-assignee="<%= assigneeId %>">×</span>
                            <% } else {%>
-                            <%= HTML.File(this, 'files.' + assigneeId) %>
+                            <%= HTML.File(this, 'displayFiles.' + assigneeId) %>
                         <% } %>
                       <% } %>
                       <% } else { %>
@@ -57,7 +57,7 @@ if (assignees && assignees.length > 0) {
                     </td>
                     <td valign="top">
                         <%
-                            var selectedReviewerId = reviewers[assigneeId] || null;
+                            var selectedReviewerId = displayReviewers[assigneeId] || null;
                             var peopleList = this.project.members.map(function(member) {
                                 return { value: member.get('id'), option: member.get('fullName') };
                             });
@@ -70,7 +70,7 @@ if (assignees && assignees.length > 0) {
                                 return person.value != assigneeId;
                             });
                             %>
-                            <%= HTML.Select(this, 'reviewers.' + assigneeId + '.id', {
+                            <%= HTML.Select(this, 'displayReviewers.' + assigneeId + '.id', {
                                 options: reviewerOptions
                             }) %>
                         <% } else { %>
@@ -95,7 +95,5 @@ if (assignees && assignees.length > 0) {
 }
 %>
 
-<% if (isEditableStatus) { %>  
-    <button id="updateStatusButton">Update Status</button>
-<% } %>
-<button id="cancelButton">Cancel</button>
+
+<button id="cancelButton">Close</button>

--- a/extensions/GrandObjectPage/LIMSPmm/Templates/lims_task.html
+++ b/extensions/GrandObjectPage/LIMSPmm/Templates/lims_task.html
@@ -4,9 +4,15 @@
     var assigneesList = this.model.get('assignees'); // Assuming 'assignees' is an array of assignee objects
     if (assigneesList && assigneesList.length > 0) {
         assigneesList.forEach(function(assignee, index) {
+            if (assignee.id == -1) {
+            %>
+                <div>Everyone</div>
+            <%
+            } else {
             %>
             <div><a href="<%= assignee.url %>"><%= assignee.name %></a></div>
             <% 
+            }
         });
     } else {
         %>

--- a/extensions/GrandObjectPage/LIMSPmm/Templates/lims_task_edit.html
+++ b/extensions/GrandObjectPage/LIMSPmm/Templates/lims_task_edit.html
@@ -2,14 +2,19 @@
     <td valign="top"><span id="deleteTask" class="delete-icon" style="margin: 7px 5px 0 5px;" title="Delete Task"></span></td>
     <td valign="top"><%= HTML.TextBox(this, 'task', {placeholder: 'Enter Task...', style: "width:100%;box-sizing:border-box;margin:0;"}) %></td>
     <% if(isLeaderAllowedToEdit){ %>
+        <%
+        var memberOptions =  _.map(this.project.members.toJSON(), function(person) {
+            return {option: person.fullName, value: person.id};
+        })
+        var allOptions = [
+            {option: 'Everyone', value: -1}
+        ].concat(memberOptions);
+        %>
         <td valign="top">
             <%= HTML.Select(this, 'assignees', {
                 style: 'width:200px; display: none',
                 multiple: true,
-                options: 
-                    _.map(this.project.members.toJSON(), function(person) {
-                        return {option: person.fullName, value: person.id};
-                    }),
+                options: allOptions,
             }) %>
         </td>
     <% } else { %>

--- a/extensions/GrandObjectPage/LIMSPmm/Views/LIMSContactEditViewPmm.js
+++ b/extensions/GrandObjectPage/LIMSPmm/Views/LIMSContactEditViewPmm.js
@@ -144,6 +144,11 @@ LIMSContactEditViewPmm = Backbone.View.extend({
         this.model.opportunities.each(function(model){
             model.tasks.each(function(task){
                 task.set('opportunity', model.get('id'));
+                task.unset('displayAssignees');
+                task.unset('displayStatuses');
+                task.unset('displayFiles');
+                task.unset('displayReviewers');
+                task.unset('displayComments');
                 task.saving = true;
                 if(!task.toDelete){
                     // Create or Update


### PR DESCRIPTION
Fixes: https://github.com/UniversityOfAlberta/GrandForum/issues/260

We can now assign an "Everyone" assignee option (ID -1) that dynamically includes all project members without creating a db entry for each assignee. When a meaningful change (e.g., adds a file, changes a status) is made to an assignee under the "Everyone" group, we promote that assignee into an explicit assignee which then creates a db entry for that respective assignee. This means we won't be assigning a random reviewer to the "Everyone" group. To keep things simple, temporary UI state is stored separately from the model’s core data, then reconciled at update time and discarded afterward to maintain data integrity.

This has also fixed another small issue, where the assignee name would not appear in the status change dialog after we add a new assignee to the task.