### PR TITLE
Fix bug where assignees can't edit their respective task's status

### DIFF
--- a/extensions/GrandObjectPage/LIMSPmm/Templates/lims_status_change.html
+++ b/extensions/GrandObjectPage/LIMSPmm/Templates/lims_status_change.html
@@ -15,54 +15,69 @@ if (displayAssignees && displayAssignees.length > 0) {
         </thead>
         <tbody>
             <% displayAssignees.forEach(function(assignee, index) { %>
+                 <% 
+                    var assigneeId = (assignee.id != undefined) ? assignee.id : assignee; 
+                    var currentStatus = displayStatuses[assigneeId];
+
+                    var isCurrentUserTheAssignee = (me.get('id') == assigneeId);
+                    
+                    var reviewer = displayReviewers[assigneeId];
+                    var isCurrentUserTheReveiwer = reviewer && (me.get('id') == reviewer.id);
+                    
+                    var allStatusOptions = ['New', 'Assigned', 'Done', 'Closed'];
+                    var assigneeStatusOptions = ['Assigned', 'Done'];
+
+                    var isStatusEditableByMember = _.contains(assigneeStatusOptions, currentStatus);
+                    var isMemberAllowedToEdit = isCurrentUserTheAssignee && isStatusEditableByMember;
+                    
+                    var canCurrentUserEdit = isLeaderAllowedToEdit || isMemberAllowedToEdit;
+                %>
                 <tr>
                     <td valign="top"><%= assignee.name %></td>
                     <td valign="top">
-                        <% 
-                        var assigneeId = (assignee.id != undefined) ? assignee.id : assignee; 
-                        var currentStatus = displayStatuses[assigneeId]; // Get current status for the assignee
-                        %>
-                        
-                        <% if (isLeaderAllowedToEdit || (me.get('id') == assigneeId && (currentStatus == 'Assigned' || currentStatus == 'Done'))) { %> 
+                        <%
+                        if (canCurrentUserEdit || isCurrentUserTheReveiwer) { 
+                        %> 
                             <%= HTML.Select(this, 'displayStatuses.' + assigneeId, { 
                                 options: 
                                     isLeaderAllowedToEdit 
-                                        ? ['New', 'Assigned', 'Done', 'Closed'] 
-                                        : ['Assigned', 'Done'] 
-                            }) %>
+                                        ? allStatusOptions 
+                                        : assigneeStatusOptions,
+                            }) 
+                        %>
                         <% } else { %> 
                             <%= currentStatus %>
                         <% } %> 
                     </td>
-                    <td valign="top" height>
-                      <% 
-                        var fileObj  = (displayFiles && displayFiles[assigneeId]) || {};
-                        var filename = fileObj.filename || '';
-                        var toDelete = fileObj.delete || false;
-                      %>
-                      <% if (isLeaderAllowedToEdit || ( me.get('id') == assigneeId && ( currentStatus == 'Assigned' || currentStatus == 'Done' ) ) ) { %>
+                    <td valign="top">
+                        <%
+                            var fileObj  = (displayFiles && displayFiles[assigneeId]) || {};
+                            var filename = fileObj.filename || '';
+                            var fileUrl  = fileObj.url || '#';
+                            var toDelete = fileObj.delete || false;
+                        %>
+
                         <% if (currentStatus !== 'Closed') { %>
-                        <% if (filename && !toDelete) { %>
-                                <%= filename %>
-                                  <span class="delete-icon deleteFile" data-assignee="<%= assigneeId %>">×</span>
-                           <% } else {%>
-                            <%= HTML.File(this, 'displayFiles.' + assigneeId) %>
-                        <% } %>
-                      <% } %>
-                      <% } else { %>
-                        <% if (currentStatus !== 'Closed') { %>
-                          <span>No document allowed</span>
-                        <% } %>
+                            <% if (canCurrentUserEdit) { %>
+                                <% if (filename && !toDelete) { %>
+                                    <a href="<%= fileUrl %>" target="_blank"><%= filename %></a>
+                                    <span class="delete-icon deleteFile" data-assignee="<%= assigneeId %>">×</span>
+                                <% } else { %>
+                                    <%= HTML.File(this, 'displayFiles.' + assigneeId) %>
+                                <% } %>
+                            <% } else if (isCurrentUserTheReveiwer && filename) { %>
+                                <a href="<%= fileUrl %>" target="_blank"><%= filename %></a>
+                            <% } else { %>
+                                <span>No document allowed</span>
+                            <% } %>
+
                         <% } %>
                     </td>
                     <td valign="top">
                         <%
-                            var selectedReviewerId = displayReviewers[assigneeId] || null;
                             var peopleList = this.project.members.map(function(member) {
                                 return { value: member.get('id'), option: member.get('fullName') };
                             });
-                            var reviewerMember = _.find(peopleList, function(p) { return p.value == selectedReviewerId; });
-                            var reviewerName = reviewerMember ? reviewerMember.option : "Not Assigned";
                         %>
                         <% if (isLeaderAllowedToEdit) { %>
                             <%
@@ -74,14 +89,14 @@ if (displayAssignees && displayAssignees.length > 0) {
                                 options: reviewerOptions
                             }) %>
                         <% } else { %>
-                            <%= reviewerName %>
+                            <%= reviewer ? reviewer.name : "Not Assigned" %>
                         <% } %>
                     </td>
 
                     <td valign="top" height>
-                        <% if (isLeaderAllowedToEdit || (me.get('id') == assigneeId && (currentStatus == 'Assigned' || currentStatus == 'Done'))) { %> 
-                            <%= HTML.TextArea(this, 'comments.' + assigneeId, {placeholder: "Enter your comments here", style: "height: 75px;width:100%;box-sizing:border-box;margin:0;"}) %>                        <% } %> 
-                           
+                        <% if (canCurrentUserEdit || isCurrentUserTheReveiwer) { %> 
+                            <%= HTML.TextArea(this, 'comments.' + assigneeId, {placeholder: "Enter your comments here", style: "height: 75px;width:100%;box-sizing:border-box;margin:0;"}) %>
+                        <% } %>   
                     </td>
                 </tr>
             <% }.bind(this)); %>

--- a/extensions/GrandObjectPage/LIMSPmm/Templates/lims_status_change.html
+++ b/extensions/GrandObjectPage/LIMSPmm/Templates/lims_status_change.html
@@ -65,7 +65,7 @@ if (displayAssignees && displayAssignees.length > 0) {
                                 <% } else { %>
                                     <%= HTML.File(this, 'displayFiles.' + assigneeId) %>
                                 <% } %>
-                            <% } else if (isCurrentUserTheReveiwer && filename) { %>
+                            <% } else if (filename) { %>
                                 <a href="<%= fileUrl %>" target="_blank"><%= filename %></a>
                             <% } else { %>
                                 <span>No document allowed</span>

--- a/extensions/GrandObjectPage/LIMSPmm/Templates/lims_status_change.html
+++ b/extensions/GrandObjectPage/LIMSPmm/Templates/lims_status_change.html
@@ -26,11 +26,8 @@ if (displayAssignees && displayAssignees.length > 0) {
                     
                     var allStatusOptions = ['New', 'Assigned', 'Done', 'Closed'];
                     var assigneeStatusOptions = ['Assigned', 'Done'];
-
-                    var isStatusEditableByMember = _.contains(assigneeStatusOptions, currentStatus);
-                    var isMemberAllowedToEdit = isCurrentUserTheAssignee && isStatusEditableByMember;
                     
-                    var canCurrentUserEdit = isLeaderAllowedToEdit || isMemberAllowedToEdit;
+                    var canCurrentUserEdit = isLeaderAllowedToEdit || isCurrentUserTheAssignee;
                 %>
                 <tr>
                     <td valign="top"><%= assignee.name %></td>

--- a/extensions/GrandObjectPage/LIMSPmm/Templates/lims_task_edit.html
+++ b/extensions/GrandObjectPage/LIMSPmm/Templates/lims_task_edit.html
@@ -44,7 +44,13 @@
         if (assigneesList && assigneesList.length > 0) {
             assigneesList.forEach(function(assignee, index) {
                 %>
-                <div><a href="<%= assignee.url %>"><%= assignee.name %></a></div>
+                <div>
+                    <% if (assignee.id === -1) { %>
+                        <%= assignee.name %>
+                    <% } else { %>
+                        <a href="<%= assignee.url %>"><%= assignee.name %></a>
+                    <% } %>
+                </div>
                 <% 
             });
         } else {
@@ -57,40 +63,17 @@
     <td align="center"><%= dueDate %></td>
     
 <% } %>
+ <td valign="top" style="white-space:nowrap;">
+    <button id="changeStatusButton" type="button">Change Status</button>
+    <div id="changeStatusDialog"></div>
+</td>
 <% if(isLeaderAllowedToEdit){ %>
-    <td valign="top" style="white-space:nowrap;">
-        <button id="changeStatusButton" type="button">Change Status</button>
-        <div id="changeStatusDialog"></div>
-    </td>
-
     <td valign="top" style="white-space:nowrap; width:40%">
-        <%= HTML.TextArea(this, 'details', {style: "height: 63px;width:100%;box-sizing:border-box;margin:0;"}) %>
-
+        <%= HTML.TextArea(this, 'details', {style: "height: 63px;width:100%;box-sizing:border-box;margin:0;"}) %> 
     </td>
-    
-<% } else if(isMemberAllowedToEdit) { %>
-    <td valign="top" style="white-space:nowrap;">
-        <button id="changeStatusButton" type="button">Change Status</button>
-        <div id="changeStatusDialog"></div>
-    </td>
-
-    <td valign="top" style="white-space:nowrap; width:40%">
-        <%= HTML.TextArea(this, 'details', {style: "height: 63px;width:100%;box-sizing:border-box;margin:0;"}) %>
-
-    </td>
-    
-
 <% } else { %>
-    <td valign="top" style="white-space:nowrap;">
-        <button id="changeStatusButton" type="button">Change Status</button>
-        <div id="changeStatusDialog"></div>
-    </td>
-
     <td valign="top" style="white-space:nowrap; width:40%">
-        <%= HTML.TextArea(this, 'details', {style: "height: 63px;width:100%;box-sizing:border-box;margin:0;"}) %>
-
+        <%= details %>
     </td>
-    
-   
 <% } %>
 

--- a/extensions/GrandObjectPage/LIMSPmm/Views/LIMSTaskEditViewPmm.js
+++ b/extensions/GrandObjectPage/LIMSPmm/Views/LIMSTaskEditViewPmm.js
@@ -46,22 +46,10 @@ LIMSTaskEditViewPmm = Backbone.View.extend({
         var userRole = _.pluck(_.filter(me.get('roles'), function(el){return el.title == this.project.get("name") ||  el.role !== PL}.bind(this)), 'role');
         // Memebers can only change 'assigned' -> 'done'
         var isPLAllowed = _.intersection(userRole, [PL, STAFF, MANAGER, ADMIN]).length > 0 ;
-
-        var isMemberAllowed = !isPLAllowed && (this.model.get('status') == 'Assigned' || this.model.get('status') == 'Done');
         
-
         this.model.set('isLeaderAllowedToEdit', isPLAllowed);
-        this.model.set('isMemberAllowedToEdit', isMemberAllowed);
 
-
-        if(!this.model.get('isAllowedToEdit')){
-            // Not allowed to edit, use read-only version
-            this.template = _.template($('#lims_task_template').html());
-        }
-        else{
-            // Use Edit version
-            this.template = _.template($('#lims_task_edit_template').html());
-        }
+        this.template = _.template($('#lims_task_edit_template').html());
     },
     
     events: {

--- a/extensions/GrandObjectPage/LIMSPmm/helpers.js
+++ b/extensions/GrandObjectPage/LIMSPmm/helpers.js
@@ -7,7 +7,7 @@ var ReviewerHelper = {
 
     allAssignees.forEach(function(assignee) {
       var assigneeId = assignee.id || assignee;
-      if (assigneeId === -1) { return; }
+      if (assigneeId == -1) { return; }
       if (!_.isEmpty(updatedReviewers[assigneeId])) { return; }
       var availablePool = _.reject(preferredPool, member => member.id === assigneeId);
       if (availablePool.length === 0) {

--- a/extensions/GrandObjects/LIMSTaskPmm.php
+++ b/extensions/GrandObjects/LIMSTaskPmm.php
@@ -398,9 +398,10 @@ class LIMSTaskPmm extends BackboneModel
             foreach ($this->assignees as $assignee) {
                 $assigneeId = (isset($assignee->id)) ? $assignee->id : $assignee;
                 $assigneeId = (int)$assigneeId;
+                $currentUserId = (int)$me->getId();
 
-                $isCurrentUserTheAssignee = ($me->getId() === $assigneeId);
-                $isCurrentUserTheReviewer = (isset($data[$assigneeId]['reviewer']) && $me->getId() === (int)$data[$assigneeId]['reviewer']);
+                $isCurrentUserTheAssignee = ($currentUserId == $assigneeId);
+                $isCurrentUserTheReviewer = (isset($data[$assigneeId]['reviewer']) && $currentUserId == (int)$data[$assigneeId]['reviewer']);
                 $canUserEditThisRow = $isLeader || $isCurrentUserTheAssignee || $isCurrentUserTheReviewer;
 
                 $status = null;

--- a/extensions/GrandObjects/LIMSTaskPmm.php
+++ b/extensions/GrandObjects/LIMSTaskPmm.php
@@ -155,7 +155,7 @@ class LIMSTaskPmm extends BackboneModel
         $assignees = $this->getAssignees();
         $personId = $me->getId();
         foreach($assignees as $assignee) {
-            if ($assignee->getId() == $personId) {
+            if ($assignee->getId() == $personId || $assignee->getId() == "-1") {
                 return true;
             }
         }

--- a/extensions/GrandObjects/LIMSTaskPmm.php
+++ b/extensions/GrandObjects/LIMSTaskPmm.php
@@ -393,38 +393,89 @@ class LIMSTaskPmm extends BackboneModel
             );
 
             $this->reviewers = isset($this->reviewers) ? (array)$this->reviewers : [];
+            $isLeader = $this->getOpportunity()->isAllowedToEdit();
+
             foreach ($this->assignees as $assignee) {
                 $assigneeId = (isset($assignee->id)) ? $assignee->id : $assignee;
                 $assigneeId = (int)$assigneeId;
 
+                $isCurrentUserTheAssignee = ($me->getId() === $assigneeId);
+                $isCurrentUserTheReviewer = (isset($data[$assigneeId]['reviewer']) && $me->getId() === (int)$data[$assigneeId]['reviewer']);
+                $canUserEditThisRow = $isLeader || $isCurrentUserTheAssignee || $isCurrentUserTheReviewer;
+
+                $status = null;
+                $reviewerId = null;
+                $fileData = [];
+                if ($canUserEditThisRow) {
+                    $status = $this->statuses[$assigneeId] ?? null;
+                    if ($assigneeId !== -1) {
+                        $selectedReviewer = $this->reviewers[$assigneeId] ?? null;
+                        $reviewerId = (is_object($selectedReviewer) && !empty((array)$selectedReviewer) && isset($selectedReviewer->id)) 
+                                    ? (int)$selectedReviewer->id 
+                                    : null;
+                    }
+                    $filesArr = (array)$this->files;
+                    $toDelete = isset($filesArr[$assigneeId]->delete) && $filesArr[$assigneeId]->delete;
+                    $toUpdate = isset($filesArr[$assigneeId]->data) && $filesArr[$assigneeId]->data !== '';
+                    $hasExisting = isset($existingFiles[$assigneeId]);
+
+                    // when a new file is uploaded
+                    if($toUpdate && !$isCurrentUserTheReviewer){
+                        $updatedFile = $filesArr[$assigneeId];
+                        $fileData = [
+                            'filename' => $updatedFile->filename,
+                            'type'     => $updatedFile->type,
+                            'data'     => $updatedFile->data,
+                        ];
+                    }
+
+                    // when a file is deleted
+                    if($toDelete && !$isCurrentUserTheReviewer){
+                        $fileData = [
+                            'filename' => null,
+                            'type'     => null,
+                            'data'     => null,
+                        ];
+                    }
+
+                    // if no update or delete and then fetch the exisiting file if any
+                    if (!$toDelete && !$toUpdate && $hasExisting) {
+                        $oldFile = $existingFiles[$assigneeId];
+                        $fileData = [
+                            'filename' => $oldFile->filename,
+                            'type'     => $oldFile->type,
+                            'data'     => $oldFile->data,
+                        ];
+                    }
+                } else {
+                    // current user cannot edit so just get the old data
+                    $originalRow = $data[$assigneeId] ?? [];
+                    $status   = $originalRow['status'] ?? null;
+                    $reviewerId = $originalRow['reviewer'] ?? null;
+
+                    if (isset($existingFiles[$assigneeId])) {
+                        $oldFile = $existingFiles[$assigneeId];
+                        $fileData = [
+                            'filename' => $oldFile->filename,
+                            'type'     => $oldFile->type,
+                            'data'     => $oldFile->data,
+                        ];
+                    }
+                }
                 $insertData = [
                     'task_id'  => $this->id,
                     'assignee' => $assigneeId,
-                    'status'   => @$this->statuses[$assigneeId]
+                    'status'   => $status,
+                    'reviewer' => $reviewerId,
                 ];
-                if ($assigneeId !== -1) {
-                    $selectedReviewer = $this->reviewers[$assigneeId] ?? null;
-                    $reviewerValue = (is_object($selectedReviewer) && !empty((array)$selectedReviewer) && isset($selectedReviewer->id)) 
-                        ? (int)$selectedReviewer->id 
-                        : null;
-                    $insertData['reviewer'] = $reviewerValue;
-                }
 
-                $filesArr = (array)$this->files;
-                $toDelete = isset($filesArr[$assigneeId]->delete) && $filesArr[$assigneeId]->delete;
-                $toUpdate = isset($filesArr[$assigneeId]->data) && $filesArr[$assigneeId]->data !== '';
-                $hasExisting = isset($existingFiles[$assigneeId]);
-                if (!$toDelete && !$toUpdate && $hasExisting) {
-                    $old = $existingFiles[$assigneeId];
-                    $insertData['filename'] = $old->filename;
-                    $insertData['type']     = $old->type;
-                    $insertData['data']     = $old->data;
+                if (!empty($fileData)) {
+                    $insertData = array_merge($insertData, $fileData);
                 }
                 DBFunctions::insert(
                     'grand_pmm_task_assignees',
                     $insertData);
             }
-            $this->uploadFiles();
             $assignees = $this->getAssignees();            
             foreach ($assignees as $assignee) {
                 $comment = @$_POST['comments'][$assignee->id];


### PR DESCRIPTION
Fixes: https://github.com/UniversityOfAlberta/GrandForum/issues/270

The existing code had a check according to which an assignee was unable to change a task he was assigned to unless the status was set to 'Assigned' or 'Done'. Removing this condition allowed assignees to change the tasks they were assigned to even though a status was not set. I also updated the isMember() check in order to make sure assignees can look into a task which is assigned to 'Everyone'.

Further, I removed the isMemberAllowed check from task edit template, which would now let the user open the 'Change Status' dialog box for tasks to which they are not assigned to.