### PR TITLE
Improve Assignee Field UX for 'Everyone' Selection

### DIFF
--- a/extensions/GrandObjectPage/LIMSPmm/Templates/lims_task.html
+++ b/extensions/GrandObjectPage/LIMSPmm/Templates/lims_task.html
@@ -2,25 +2,20 @@
 <td><%= taskType %></td>
 <td>
     <% 
-    var assigneesList = this.model.get('assignees'); // Assuming 'assignees' is an array of assignee objects
-    if (assigneesList && assigneesList.length > 0) {
-        assigneesList.forEach(function(assignee, index) {
-            if (assignee.id == -1) {
-            %>
-                <div>Everyone</div>
-            <%
-            } else {
-            %>
-            <div><a href="<%= assignee.url %>"><%= assignee.name %></a></div>
-            <% 
-            }
-        });
-    } else {
-        %>
-        <div>No Assignees</div>
-        <%
-    }
-    %>
+    var assigneesList = this.model.get('assignees') || [];
+    var isEveryoneAssigned = _.some(assigneesList, function(a) { return a.id === -1; });
+
+    if (isEveryoneAssigned) { %>
+        <div>Everyone</div>
+    <% } else {
+        if (assigneesList.length > 0) {
+            assigneesList.forEach(function(assignee) { %>
+                <div><a href="<%= assignee.url %>"><%= assignee.name %></a></div>
+            <% });
+        } else { %>
+            <div>No Assignees</div>
+        <% }
+    } %>
 </td>
 <td style="text-align: center;"><%= dueDate %></td>
 <td style="text-align: center; white-space:nowrap; padding: 5px;">


### PR DESCRIPTION
Previously, if a user explicitly removed an individual assignee while "Everyone" was active, that assignee's data was lost and an incorrect default record was created for them. To prevent this, the UI no longer displays individual assignees when "Everyone" is chosen. This simplification prevents the user from performing the action that makes the assignment state unambiguous.